### PR TITLE
Fixed leaking `IJSObjectReference`s in `CreateAsync` methods of `AbortController`, `CustomEvent`, `Event`, and `EventTarget`.

### DIFF
--- a/src/KristofferStrube.Blazor.DOM/Abort/AbortController.cs
+++ b/src/KristofferStrube.Blazor.DOM/Abort/AbortController.cs
@@ -33,10 +33,9 @@ public class AbortController : BaseJSWrapper, IJSCreatable<AbortController>
     /// <returns>A wrapper instance for a <see cref="AbortController"/>.</returns>
     public static async Task<AbortController> CreateAsync(IJSRuntime jSRuntime)
     {
-        IJSObjectReference helper = await jSRuntime.GetHelperAsync();
+        await using IJSObjectReference helper = await jSRuntime.GetHelperAsync();
         IJSObjectReference jSInstance = await helper.InvokeAsync<IJSObjectReference>("constructAbortController");
-        AbortController abortController = new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
-        return abortController;
+        return new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
     }
 
     /// <inheritdoc/>

--- a/src/KristofferStrube.Blazor.DOM/Events/CustomEvent.cs
+++ b/src/KristofferStrube.Blazor.DOM/Events/CustomEvent.cs
@@ -32,9 +32,9 @@ public class CustomEvent : Event, IJSCreatable<CustomEvent>
     /// <returns>A wrapper instance for a <see cref="CustomEvent"/>.</returns>
     public static async Task<CustomEvent> CreateAsync(IJSRuntime jSRuntime, string type, CustomEventInit? eventInitDict = null)
     {
-        IJSObjectReference helper = await jSRuntime.GetHelperAsync();
+        await using IJSObjectReference helper = await jSRuntime.GetHelperAsync();
         IJSObjectReference jSInstance = await helper.InvokeAsync<IJSObjectReference>("constructCustomEvent", type, eventInitDict);
-        return new CustomEvent(jSRuntime, jSInstance, new() { DisposesJSReference = true });
+        return new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
     }
 
     /// <inheritdoc/>

--- a/src/KristofferStrube.Blazor.DOM/Events/Event.cs
+++ b/src/KristofferStrube.Blazor.DOM/Events/Event.cs
@@ -32,10 +32,9 @@ public class Event : BaseJSWrapper, IJSCreatable<Event>
     /// <returns>A wrapper instance for a <see cref="Event"/>.</returns>
     public static async Task<Event> CreateAsync(IJSRuntime jSRuntime, string type, EventInit? eventInitDict = null)
     {
-        IJSObjectReference helper = await jSRuntime.GetHelperAsync();
+        await using IJSObjectReference helper = await jSRuntime.GetHelperAsync();
         IJSObjectReference jSInstance = await helper.InvokeAsync<IJSObjectReference>("constructEvent", type, eventInitDict);
-        Event eventInstance = new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
-        return eventInstance;
+        return new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
     }
 
     /// <inheritdoc/>

--- a/src/KristofferStrube.Blazor.DOM/Events/EventTarget.cs
+++ b/src/KristofferStrube.Blazor.DOM/Events/EventTarget.cs
@@ -33,10 +33,9 @@ public class EventTarget : BaseJSWrapper, IJSCreatable<EventTarget>
     /// <returns>A wrapper instance for a <see cref="EventTarget"/>.</returns>
     public static async Task<EventTarget> CreateAsync(IJSRuntime jSRuntime, ElementReference element)
     {
-        IJSObjectReference helper = await jSRuntime.GetHelperAsync();
+        await using IJSObjectReference helper = await jSRuntime.GetHelperAsync();
         IJSObjectReference jSReference = await helper.InvokeAsync<IJSObjectReference>("getJSReference", element);
-        EventTarget eventTarget = new(jSRuntime, jSReference, new() { DisposesJSReference = true });
-        return eventTarget;
+        return new(jSRuntime, jSReference, new() { DisposesJSReference = true });
     }
 
     /// <summary>
@@ -46,10 +45,9 @@ public class EventTarget : BaseJSWrapper, IJSCreatable<EventTarget>
     /// <returns>A wrapper instance for a <see cref="EventTarget"/>.</returns>
     public static async Task<EventTarget> CreateAsync(IJSRuntime jSRuntime)
     {
-        IJSObjectReference helper = await jSRuntime.GetHelperAsync();
+        await using IJSObjectReference helper = await jSRuntime.GetHelperAsync();
         IJSObjectReference jSInstance = await helper.InvokeAsync<IJSObjectReference>("constructEventTarget");
-        EventTarget eventTarget = new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
-        return eventTarget;
+        return new(jSRuntime, jSInstance, new() { DisposesJSReference = true });
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Fixes #16 